### PR TITLE
Update forecast.io API integration to work with current API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .dat*
 
 .repl_history
+build

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "bubble-wrap", "~> 1.3.0"
+gem 'rake'
+gem 'afmotion'
+gem 'bubble-wrap', require: ['bubble-wrap/core', 'bubble-wrap/reactor']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,68 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bubble-wrap (1.3.0)
+    activesupport (4.2.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    afmotion (2.5)
+      motion-cocoapods (>= 1.4.1)
+      motion-require (>= 0.1)
+    bubble-wrap (1.8.0)
+    claide (0.8.1)
+    cocoapods (0.37.2)
+      activesupport (>= 3.2.15)
+      claide (~> 0.8.1)
+      cocoapods-core (= 0.37.2)
+      cocoapods-downloader (~> 0.9.0)
+      cocoapods-plugins (~> 0.4.2)
+      cocoapods-trunk (~> 0.6.1)
+      cocoapods-try (~> 0.4.5)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      molinillo (~> 0.2.3)
+      nap (~> 0.8)
+      xcodeproj (~> 0.24.2)
+    cocoapods-core (0.37.2)
+      activesupport (>= 3.2.15)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 0.8.0)
+    cocoapods-downloader (0.9.0)
+    cocoapods-plugins (0.4.2)
+      nap
+    cocoapods-trunk (0.6.1)
+      nap (>= 0.8)
+      netrc (= 0.7.8)
+    cocoapods-try (0.4.5)
+    colored (1.2)
+    escape (0.0.4)
+    fuzzy_match (2.0.4)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.7.0)
+    molinillo (0.2.3)
+    motion-cocoapods (1.7.1)
+      cocoapods (>= 0.34)
+    motion-require (0.2.0)
+    nap (0.8.0)
+    netrc (0.7.8)
+    rake (10.4.2)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcodeproj (0.24.2)
+      activesupport (>= 3)
+      colored (~> 1.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bubble-wrap (~> 1.3.0)
+  afmotion
+  bubble-wrap
+  rake
+
+BUNDLED WITH
+   1.10.2

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ I've open sourced it because it was never put up on the MAS (Mac App Store) and 
 from it.
 
 Feel free to send PR's if you would like.
+
+### Registering an API key
+
+To use the Forecast.io API, you need to register for an API key: https://developer.forecast.io. Then you can update the `API_KEY` variable found in `weather.rb`.

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,6 @@
 $:.unshift("/Library/RubyMotion/lib")
 require "motion/project/template/osx"
 require "bundler"
-require "bubble-wrap/reactor"
-
 Bundler.require
 
 Motion::Project::App.setup do |app|
@@ -24,6 +22,6 @@ Motion::Project::App.setup do |app|
   app.frameworks += ["CoreLocation", "Security"]
 
   app.detect_dependencies = false
-  app.deployment_target = "10.8"
+  app.deployment_target = "10.9"
   app.sdk_version = "10.8"
 end

--- a/app/location.rb
+++ b/app/location.rb
@@ -21,13 +21,13 @@ module FC
       location_manager.stopUpdatingLocation
       puts "Location recieved"
       coordinates = new_location.coordinate
-      location = "#{coordinates.width},#{coordinates.height}"
+      location = "#{coordinates.latitude},#{coordinates.longitude}"
       App::Persistence[:location] = location
       @callback.call(location)
     end
 
     def locationManager(manager, didFailWithError: error)
-      puts "Error recieved"
+      puts "Error received"
       location_manager.stopUpdatingLocation
 
       case error.code

--- a/app/weather.rb
+++ b/app/weather.rb
@@ -2,12 +2,14 @@ module FC
   module Weather
     module_function
 
+    API_KEY = 'YOUR_API_KEY' # https://developer.forecast.io
+
     def get(location, &block)
       @callback = block
-
-      BW::HTTP.get("https://api.forecast.io/forecast/APIKEY/#{location}?units=auto&exclude=[minutely,daily]") do |response|
+      url = "https://api.forecast.io/forecast/#{API_KEY}/#{location}?units=auto&exclude=[minutely,daily]"
+      AFMotion::JSON.get(url) do |response|
         if response.ok?
-          json = BW::JSON.parse(response.body.to_s)
+          json = response.object
           current = json["currently"]
           next_hour = json["hourly"]["data"][1]
           units = find_units(json["flags"]["units"])
@@ -15,6 +17,7 @@ module FC
           @callback.call(current, next_hour, units)
           FC::Mixpanel.event("weather_success")
         else
+          puts "API Error: #{response.status_code}: #{response.status_description}"
           notification = NSUserNotification.alloc.init
           notification.title = "Error"
           notification.informativeText = "There was an error retrieving the lastest weather report."


### PR DESCRIPTION
This PR updates the code to work with the current forecast.io API. Also updated to the latest bubble wrap and afmotion gems to be in-line with current approaches.
